### PR TITLE
applications -> extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Coney.Mixfile do
 
   def application do
     [
-      applications: [],
+      extra_applications: [],
       mod: {Coney.Application, []}
     ]
   end


### PR DESCRIPTION
```
applications: []
```
explicitly obstructs `amqp` to appear in release build, after Elixir 1.4 preferred way is not to put explicit list of OTP apps here