### PR TITLE
Error friendly coney

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ erl_crash.dump
 .idea
 *.iml
 .DS_Store
+.elixir_ls/

--- a/lib/coney/consumer.ex
+++ b/lib/coney/consumer.ex
@@ -1,9 +1,11 @@
 defmodule Coney.Consumer do
+  @type stacktrace :: []
+  @type error_tuple :: {exception :: struct(), stacktrace}
   @callback connection() :: map()
   @callback parse(message :: binary(), meta :: map()) :: any
   @callback process(payload :: any, meta :: map()) ::
               :ok | :reject | :redeliver | {:reply, binary()}
-  @callback error_happend(exception :: struct(), message :: binary(), meta :: map()) ::
+  @callback error_happend(error :: error_tuple(), message :: binary(), meta :: map()) ::
               :ok | :reject | :redeliver | {:reply, binary()}
 
   @optional_callbacks connection: 0, error_happend: 3

--- a/lib/coney/consumer.ex
+++ b/lib/coney/consumer.ex
@@ -1,12 +1,13 @@
 defmodule Coney.Consumer do
   @type stacktrace :: []
-  @type error_tuple :: {exception :: struct(), stacktrace}
   @callback connection() :: map()
   @callback parse(message :: binary(), meta :: map()) :: any
   @callback process(payload :: any, meta :: map()) ::
               :ok | :reject | :redeliver | {:reply, binary()}
-  @callback error_happend(error :: error_tuple(), message :: binary(), meta :: map()) ::
+  @callback error_happend(exception :: struct(), message :: binary(), meta :: map()) ::
+              :ok | :reject | :redeliver | {:reply, binary()}
+  @callback error_happend(exception :: struct(), stacktrace :: stacktrace(), message :: binary(), meta :: map()) ::
               :ok | :reject | :redeliver | {:reply, binary()}
 
-  @optional_callbacks connection: 0, error_happend: 3
+  @optional_callbacks connection: 0, error_happend: 3, error_happend: 4
 end

--- a/lib/coney/consumer_executor.ex
+++ b/lib/coney/consumer_executor.ex
@@ -8,12 +8,17 @@ defmodule Coney.ConsumerExecutor do
     |> handle_result(task)
   rescue
     exception ->
-      if function_exported?(consumer, :error_happened, 3) do
-        {exception, System.stacktrace()}
-        |> consumer.error_happened(payload, meta)
-        |> handle_result(task)
-      else
-        reject(task)
+      cond do
+        function_exported?(consumer, :error_happened, 3) ->
+          exception
+          |> consumer.error_happened(payload, meta)
+          |> handle_result(task)
+        function_exported?(consumer, :error_happened, 4) ->
+          exception
+          |> consumer.error_happened(System.stacktrace(), payload, meta)
+          |> handle_result(task)
+        true ->
+          reject(task)
       end
   end
 

--- a/lib/coney/consumer_executor.ex
+++ b/lib/coney/consumer_executor.ex
@@ -9,7 +9,7 @@ defmodule Coney.ConsumerExecutor do
   rescue
     exception ->
       if function_exported?(consumer, :error_happened, 3) do
-        exception
+        {exception, System.stacktrace()}
         |> consumer.error_happened(payload, meta)
         |> handle_result(task)
       else


### PR DESCRIPTION
Issue
At the moment, the executor does not reveal the actual source of issue when an exemption is encountered within coney's executor and also there is no straight priviledge to accession __STACKTRACE__ or System.stacktrace/0 outside of rescue.

Solution
create an optional error_happend/4 callback: 

` @callback error_happend(exception :: struct(), stacktrace :: stacktrace(), message :: binary(), meta :: map()) ::
              :ok | :reject | :redeliver | {:reply, binary()}`

Benefit

Makes error discovery faster
Better debugging, happy developer.