### PR TITLE
Fix typo in optional callbacks

### DIFF
--- a/lib/coney/consumer.ex
+++ b/lib/coney/consumer.ex
@@ -14,5 +14,5 @@ defmodule Coney.Consumer do
             ) ::
               :ok | :reject | :redeliver | {:reply, binary()}
 
-  @optional_callbacks connection: 0, error_happend: 3, error_happend: 4
+  @optional_callbacks connection: 0, error_happened: 3, error_happened: 4
 end


### PR DESCRIPTION
There were some typos:

`@optional_callbacks connection: 0, error_happend: 3, error_happend: 4`

instead of

`@optional_callbacks connection: 0, error_happened: 3, error_happened: 4`