### PR TITLE
Support for connection options

### DIFF
--- a/lib/coney/consumer.ex
+++ b/lib/coney/consumer.ex
@@ -14,5 +14,5 @@ defmodule Coney.Consumer do
             ) ::
               :ok | :reject | :redeliver | {:reply, binary()}
 
-  @optional_callbacks connection: 0, error_happend: 3, error_happend: 4
+  @optional_callbacks connection: 0, error_happened: 3, error_happened: 4
 end

--- a/lib/coney/rabbit_connection.ex
+++ b/lib/coney/rabbit_connection.ex
@@ -3,27 +3,34 @@ defmodule Coney.RabbitConnection do
 
   require Logger
 
-  def open(settings = %{url: url, timeout: timeout}) do
-    case connect(url) do
+  @timeout 1000
+
+  def open(settings) do
+    case connect(settings) do
       {:ok, conn} ->
-        Logger.debug("#{__MODULE__} (#{inspect(self())}) connected to #{url}")
+        Logger.debug("#{__MODULE__} (#{inspect(self())}) connected to server")
 
         Process.monitor(conn.pid)
         conn
 
       {:error, error} ->
         Logger.error(
-          "#{__MODULE__} (#{inspect(self())}) connection to #{url} refused: #{inspect(error)}"
+          "#{__MODULE__} (#{inspect(self())}) connection to server refused: #{inspect(error)}"
         )
 
-        :timer.sleep(timeout)
+        :timer.sleep(@timeout)
         open(settings)
     end
   end
 
-  defp connect(url) do
+  defp connect(%{url: url}) do
     url
     |> choose_server()
+    |> Connection.open()
+  end
+  defp connect(settings = %{}) do
+    settings
+    |> Enum.into([])
     |> Connection.open()
   end
 


### PR DESCRIPTION
Very basic support for connection options.

Basically if it finds the key `:url` it uses it, otherwise it transforms the `settings` map into a keyword list and passes it to `AMQP.Connection.open/2`.